### PR TITLE
Support passing `user_project` argument to GCS bucket to support GCS buckets with “Requester pays” enabled

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Support passing `user_project` argument to GCS bucket to support GCS buckets with “Requester pays” enabled
+
+    *Tom Naessens*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -159,6 +159,10 @@ module ActiveStorage
           args[:signer] = signer
         end
 
+        if user_project
+          args[:query][:userProject] = user_project
+        end
+
         file_for(key).signed_url(**args)
       end
 
@@ -189,11 +193,11 @@ module ActiveStorage
       end
 
       def bucket
-        @bucket ||= client.bucket(config.fetch(:bucket), skip_lookup: true)
+        @bucket ||= client.bucket(config.fetch(:bucket), skip_lookup: true, user_project: user_project)
       end
 
       def client
-        @client ||= Google::Cloud::Storage.new(**config.except(:bucket, :cache_control, :iam, :gsa_email))
+        @client ||= Google::Cloud::Storage.new(**config.except(:bucket, :cache_control, :iam, :gsa_email, :user_project))
       end
 
       def issuer
@@ -227,6 +231,10 @@ module ActiveStorage
 
       def custom_metadata_headers(metadata)
         metadata.transform_keys { |key| "x-goog-meta-#{key}" }
+      end
+
+      def user_project
+        config.fetch(:user_project, nil)
       end
   end
 end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -198,6 +198,15 @@ if SERVICE_CONFIGURATIONS[:gcs]
         assert_match(/storage\.googleapis\.com\/.*response-content-disposition=inline.*test\.txt.*response-content-type=text%2Fplain/,
           service.url(key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
       end
+
+      test "url for requester pays bucket" do
+        config_with_user_project = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ user_project: "a_user_project" }) }
+        service = ActiveStorage::Service.configure(:gcs, config_with_user_project)
+
+        key = SecureRandom.base58(24)
+        assert_match(/storage\.googleapis\.com\/.*userProject=a_user_project/,
+          service.url(key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
+      end
     end
   end
 else

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -290,6 +290,15 @@ google:
   gsa_email: "foobar@baz.iam.gserviceaccount.com"
 ```
 
+Optionally set a [UserProject](https://cloud.google.com/storage/docs/using-requester-pays#using) to support ["Requester Pays" buckets](https://cloud.google.com/storage/docs/requester-pays). 
+
+```yaml
+google:
+  service: GCS
+  ...
+  user_project: "a-user-project"
+```
+
 Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/main/google-cloud-storage) gem to your `Gemfile`:
 
 ```ruby


### PR DESCRIPTION
### Motivation / Background

GCS has an option on buckets to make them a "Requester Pays" type of bucket: https://cloud.google.com/storage/docs/requester-pays. In short, this allows tracing of who/what is actually requesting an upload/download to be able to allocate the costs to the project used.

To query a bucket where "requester pays" is enabled, the `userProject` needs to be added in the URL. The GCS Ruby library provides this as an optional `user_project` keyword argument to `Project#bucket`: https://github.com/googleapis/google-cloud-ruby/blob/google-cloud-storage/v1.11.0/google-cloud-storage/lib/google/cloud/storage/project.rb#L87-L99 (took v1.11 explicitly here as this is the current version requirement on Rails.)

When this is not passed, an error is thrown when listing/uploading files in a requester-pays bucket: `Bucket is a requester pays bucket but no user project provided. (Google::Cloud::InvalidArgumentError)`

### Detail

This commit adds support for "requester pays"-buckets by accepting a `user_project` parameter (defaults to `nil`) on the GCS service bucket call
(https://github.com/rails/rails/blob/cd31b164b1975abfe6adb9af8e0edc8bea7ce1b0/activestorage/lib/active_storage/service/gcs_service.rb#L192), set by a variable in the config `config.fetch(:user_project, nil) `.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
